### PR TITLE
Load recipes from server

### DIFF
--- a/app/src/main/java/com/mealsmadeeasy/data/FakeMealStore.kt
+++ b/app/src/main/java/com/mealsmadeeasy/data/FakeMealStore.kt
@@ -144,33 +144,21 @@ class FakeMealStore : MealStore {
 
     override fun getRecipe(id: String): Single<Recipe> {
         val tacosRecipe = Recipe(
-                prepTime = 20,
-                steps = listOf(
-                        RecipeStep("Cut chicken into 1/2 inch strips."),
-                        RecipeStep("Heat oil in large skillet over medium-high heat, adding chicken once hot. " +
-                                "Cook and stir for 10 minutes or until cooked through."),
-                        RecipeStep("Spoon 1/3 of the chicken into each tortilla and sprinkle with cheese. " +
-                                "Top evenly with lettuce and tomato.")
-                ),
-                ingredients = listOf(
-                        Ingredient(id = "taco-shell", name = "Flour tortilla shells", quantity = 3, unitName = "Shells", isMeasurable = false),
-                        Ingredient(id = "taco-meat_chicken", name = "Chicken", quantity = 0.5, unitName = "lbs"),
-                        Ingredient(id = "shredded_cheese", name = "Shredded cheese", quantity = 0.75, unitName = "Cups"),
-                        Ingredient(id = "lettuce", name = "Lettuce leaves", quantity = 2, unitName = "Leaves", isMeasurable = false),
-                        Ingredient(id = "tomato", name = "Tomato", quantity = 0.5, unitName = "Tomatoes", isMeasurable = false)
-                )
+                content = """
+                    <p>These tacos are the best tacos ever.</p>
+                    <p>1. Cut chicken into 1/2 inch strips.</p>
+                    <p>2. Heat oil in large skillet over medium-high heat, adding chicken once hot.
+                        Cook and stir for 10 minutes or until cooked through.</p>
+                    <p>3. Spoon 1/3 of the chicken into each tortilla and sprinkle with cheese.
+                            Top evenly with lettuce and tomato.</p>
+                """
         )
 
         val iceCreamRecipe = Recipe(
-                prepTime = 5,
-                steps = listOf(
-                        RecipeStep("Take the ice cream out of the freezer, letting it thaw for 5 minutes."),
-                        RecipeStep("Scoop desired amount into bowl and top evenly with chocolate syrup.")
-                ),
-                ingredients = listOf(
-                        Ingredient(id = "ice-cream_chocolate", name = "Chocolate ice cream", quantity = 1, unitName = "Pint"),
-                        Ingredient(id = "chocolate-syrup", name = "Chocolate syrup", quantity = 1, unitName = "Fl.oz.")
-                )
+                content = """
+                    <p>🍦😍</p>
+                    <p>1. Consume directly from container.</p>
+                """
         )
 
         when (id) {

--- a/app/src/main/java/com/mealsmadeeasy/data/service/MealsMadeEasyService.kt
+++ b/app/src/main/java/com/mealsmadeeasy/data/service/MealsMadeEasyService.kt
@@ -3,6 +3,7 @@ package com.mealsmadeeasy.data.service
 import com.mealsmadeeasy.data.service.model.SparseMealPlan
 import com.mealsmadeeasy.model.Meal
 import com.mealsmadeeasy.model.MealPlan
+import com.mealsmadeeasy.model.Recipe
 import com.mealsmadeeasy.model.UserProfile
 import io.reactivex.Single
 import retrofit2.Response
@@ -41,5 +42,10 @@ interface MealsMadeEasyService {
     fun getMeal(
             @Path("id") mealId: String
     ): Single<Response<Meal>>
+
+    @GET("/recipe/{id}")
+    fun getRecipe(
+            @Path("id") mealId: String
+    ): Single<Response<Recipe>>
 
 }

--- a/app/src/main/java/com/mealsmadeeasy/model/Meal.kt
+++ b/app/src/main/java/com/mealsmadeeasy/model/Meal.kt
@@ -1,7 +1,9 @@
 package com.mealsmadeeasy.model
 
+typealias MealId = String
+
 data class Meal (
-        val id: String,
+        val id: MealId,
         val name: String,
         val description: String,
         val thumbnailUrl: String?

--- a/app/src/main/java/com/mealsmadeeasy/model/Recipe.kt
+++ b/app/src/main/java/com/mealsmadeeasy/model/Recipe.kt
@@ -1,7 +1,5 @@
 package com.mealsmadeeasy.model
 
 data class Recipe(
-        val prepTime: Minutes,
-        val steps: List<RecipeStep>,
-        val ingredients: List<Ingredient>
+        val content: String
 )

--- a/app/src/main/java/com/mealsmadeeasy/model/RecipeStep.kt
+++ b/app/src/main/java/com/mealsmadeeasy/model/RecipeStep.kt
@@ -1,5 +1,0 @@
-package com.mealsmadeeasy.model
-
-data class RecipeStep (
-        val stepDescription: String
-)

--- a/app/src/main/java/com/mealsmadeeasy/ui/meal/MealActivity.kt
+++ b/app/src/main/java/com/mealsmadeeasy/ui/meal/MealActivity.kt
@@ -55,7 +55,8 @@ class MealActivity : BaseActivity() {
     }
 
     private fun onMealLoaded(meal: Meal) {
-        supportActionBar?.title = meal.name
+        val collapsingToolbar = findViewById<android.support.design.widget.CollapsingToolbarLayout>(R.id.collapsing_toolbar)
+        collapsingToolbar.title = meal.name
 
         val thumbnailView = findViewById<ImageView>(R.id.meal_thumbnail)
         val nameView = findViewById<TextView>(R.id.meal_name)

--- a/app/src/main/java/com/mealsmadeeasy/utils/PicassoImageGetter.kt
+++ b/app/src/main/java/com/mealsmadeeasy/utils/PicassoImageGetter.kt
@@ -1,0 +1,95 @@
+package com.mealsmadeeasy.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.text.Html
+import com.squareup.picasso.Picasso
+import com.squareup.picasso.Target
+
+class PicassoImageGetter(
+        private val context: Context,
+        private val maxWidth: Int = -1,
+        private val onChangeCallback: () -> Unit
+) : Html.ImageGetter {
+
+    override fun getDrawable(source: String): Drawable {
+        return PlaceholderDrawable(context, maxWidth, onChangeCallback).also {
+            Picasso.with(context)
+                    .load(source)
+                    .into(it)
+        }
+    }
+
+}
+
+private class PlaceholderDrawable(
+        private val context: Context,
+        private val maxWidth: Int,
+        private val onChangeCallback: () -> Unit
+) : Drawable(), Target {
+
+    private var _alpha: Int = 255
+    private var _colorFilter: ColorFilter? = null
+
+    private val displayDensity = context.resources.displayMetrics.density
+
+    private var drawable: Drawable? = null
+        set(value) {
+            field = value
+            field?.alpha = _alpha
+            field?.colorFilter = _colorFilter
+
+            val originalWidth = value?.intrinsicWidth ?: 0
+
+            val scaleFactor = if (maxWidth > 0) {
+                Math.min(maxWidth / originalWidth.toFloat(), displayDensity)
+            } else {
+                1f
+            }
+
+            val width = (originalWidth * scaleFactor).toInt()
+            val height = ((value?.intrinsicHeight ?: 0) * scaleFactor).toInt()
+
+            val containerWidth = Math.max(width, maxWidth)
+            val horizontalOffset = (containerWidth - width) / 2
+
+            drawable?.setBounds(horizontalOffset, 0, containerWidth - horizontalOffset, height)
+            setBounds(0, 0, containerWidth, height)
+
+            onChangeCallback()
+        }
+
+    override fun setAlpha(alpha: Int) {
+        _alpha = alpha
+        drawable?.alpha = alpha
+    }
+
+    override fun getOpacity() = _alpha
+
+    override fun setColorFilter(colorFilter: ColorFilter?) {
+        _colorFilter = colorFilter
+    }
+
+    override fun draw(canvas: Canvas) {
+        drawable?.draw(canvas)
+    }
+
+    override fun onPrepareLoad(placeHolderDrawable: Drawable?) {
+        drawable = placeHolderDrawable
+    }
+
+    override fun onBitmapFailed(errorDrawable: Drawable?) {
+        drawable = errorDrawable
+    }
+
+    override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
+        bitmap?.let {
+            drawable = BitmapDrawable(context.resources, it)
+        }
+    }
+
+}

--- a/app/src/main/java/com/mealsmadeeasy/utils/ViewUtils.kt
+++ b/app/src/main/java/com/mealsmadeeasy/utils/ViewUtils.kt
@@ -1,0 +1,17 @@
+package com.mealsmadeeasy.utils
+
+import android.view.View
+import android.view.ViewTreeObserver
+
+inline fun <V : View> V.whenMeasured(crossinline action: V.() -> Unit) {
+    if (isLaidOut) {
+        action()
+    } else {
+        viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+            override fun onGlobalLayout() {
+                action()
+                viewTreeObserver.removeOnGlobalLayoutListener(this)
+            }
+        })
+    }
+}

--- a/app/src/main/res/layout/activity_meal.xml
+++ b/app/src/main/res/layout/activity_meal.xml
@@ -70,58 +70,8 @@
                 android:layout_marginTop="@dimen/meal_page_name_margin_top"
                 android:layout_marginBottom="@dimen/meal_page_name_margin_bottom"/>
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/meal_page_text_margin"
-                android:orientation="horizontal">
-
-                <ImageView
-                    android:id="@+id/meal_page_clock"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_clock_grey600_24dp"
-                    android:layout_marginEnd="@dimen/meal_page_text_margin"/>
-
-                <TextView
-                    android:id="@+id/meal_page_prep_time"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    style="@style/TextAppearance.AppCompat.Body1"/>
-
-            </LinearLayout>
-
-
-            <TextView
-                android:id="@+id/meal_page_steps_header"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_margin="@dimen/meal_page_text_margin"
-                style="@style/TextAppearance.AppCompat.Body1"
-                android:textStyle="bold"
-                android:text="@string/meal_page_steps_header"/>
-
             <TextView
                 android:id="@+id/meal_page_steps"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/meal_page_text_margin"
-                android:layout_marginEnd="@dimen/meal_page_text_margin"
-                style="@style/TextAppearance.AppCompat.Body1"/>
-
-            <TextView
-                android:id="@+id/meal_page_ingredients_header"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/meal_page_text_margin"
-                android:layout_marginBottom="@dimen/meal_page_text_margin"
-                style="@style/TextAppearance.AppCompat.Body1"
-                android:textStyle="bold"
-                android:text="@string/meal_page_ingredients_header"/>
-
-            <TextView
-                android:id="@+id/meal_page_ingredients"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/meal_page_text_margin"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,8 +52,6 @@
     <string name="suggestions">Suggestions</string>
     <string name="failed_to_load_suggestions">Couldn\'t access suggestions</string>
 
-    <string name="meal_page_steps_header">Directions:</string>
-    <string name="meal_page_ingredients_header">Ingredients:</string>
     <string name="meal_page_minutes">Minutes</string>
     <string name="meal_page_bullet">&#8226;</string>
     <string name="meal_page_failed_to_load_meal">Couldn\'t find that meal</string>


### PR DESCRIPTION
Depends on #46.

Not gonna lie, most of this was stolen from [Paper](https://github.com/marverenic/Paper). In a nutshell, recipes are sent from the server as HTML, so this PR updates the models to be more simple. To keep a native experience, the HTML is rendered inline, as actual HTML using the most appropriate API: ~`WebView`~ `TextView`.

Betcha didn't know that you could pressure a single `TextView` into displaying rich HTML. And images.


### Implementation status
The server might need a bit of ~encouragement~ tweaking, because some of our taco recipes return a 500 internal server error when you try to load the recipe info. Also none of the Firebase meals have recipes, so don't try those.