### PR TITLE
Add search methods

### DIFF
--- a/app/src/main/java/com/mealsmadeeasy/data/FakeMealStore.kt
+++ b/app/src/main/java/com/mealsmadeeasy/data/FakeMealStore.kt
@@ -178,4 +178,12 @@ class FakeMealStore : MealStore {
             else -> return Single.just(iceCreamRecipe)
         }
     }
+
+    override fun search(query: String, filters: List<Filter>): Single<List<Meal>> {
+        throw NotImplementedError("FakeMealStore doesn't support searching.")
+    }
+
+    override fun getAvailableFilters(): Single<List<FilterGroup>> {
+        return Single.just(emptyList())
+    }
 }

--- a/app/src/main/java/com/mealsmadeeasy/data/MealStore.kt
+++ b/app/src/main/java/com/mealsmadeeasy/data/MealStore.kt
@@ -36,4 +36,9 @@ interface MealStore {
     fun findMealById(id: String): Single<Meal>
 
     fun getRecipe(id: String): Single<Recipe>
+
+    fun search(query: String, filters: List<Filter> = emptyList()): Single<List<Meal>>
+
+    fun getAvailableFilters(): Single<List<FilterGroup>>
+
 }

--- a/app/src/main/java/com/mealsmadeeasy/data/NetMealStore.kt
+++ b/app/src/main/java/com/mealsmadeeasy/data/NetMealStore.kt
@@ -30,6 +30,12 @@ class NetMealStore(
                 .map { it.unwrap() }
     }
 
+    private val searchFilters = RxLoader {
+        service.getAvailableFilters()
+                .subscribeOn(Schedulers.io())
+                .map { it.unwrap() }
+    }
+
     override fun getMealPlan(): Observable<MealPlan> {
         return mealPlan.getOrComputeValue()
                 .observeOn(AndroidSchedulers.mainThread())
@@ -82,6 +88,17 @@ class NetMealStore(
         return service.getMeal(id).subscribeOn(Schedulers.io())
                 .map { it.unwrap() }
                 .observeOn(AndroidSchedulers.mainThread())
+    }
+
+    override fun search(query: String, filters: List<Filter>): Single<List<Meal>> {
+        return service.getSearchResults(query, filters)
+                .subscribeOn(Schedulers.io())
+                .map { it.unwrap() }
+                .observeOn(AndroidSchedulers.mainThread())
+    }
+
+    override fun getAvailableFilters(): Single<List<FilterGroup>> {
+        return searchFilters.getOrComputeValue().firstOrError()
     }
 
     private fun <T> Response<T>.unwrap(): T {

--- a/app/src/main/java/com/mealsmadeeasy/data/service/MealsMadeEasyService.kt
+++ b/app/src/main/java/com/mealsmadeeasy/data/service/MealsMadeEasyService.kt
@@ -1,9 +1,7 @@
 package com.mealsmadeeasy.data.service
 
 import com.mealsmadeeasy.data.service.model.SparseMealPlan
-import com.mealsmadeeasy.model.Meal
-import com.mealsmadeeasy.model.MealPlan
-import com.mealsmadeeasy.model.UserProfile
+import com.mealsmadeeasy.model.*
 import io.reactivex.Single
 import retrofit2.Response
 import retrofit2.http.*
@@ -41,5 +39,17 @@ interface MealsMadeEasyService {
     fun getMeal(
             @Path("id") mealId: String
     ): Single<Response<Meal>>
+
+    @GET("/meal/search")
+    fun getSearchResults(
+            @Query("q") query: String,
+            @Query("filters") filters: String
+    ): Single<Response<List<Meal>>>
+
+    @GET("/meal/search/filters")
+    fun getAvailableFilters(): Single<Response<List<FilterGroup>>>
+
+    fun getSearchResults(query: String, filters: List<Filter>)
+            = getSearchResults(query, filters.joinToString(separator = ",") { it.id })
 
 }

--- a/app/src/main/java/com/mealsmadeeasy/model/Filter.kt
+++ b/app/src/main/java/com/mealsmadeeasy/model/Filter.kt
@@ -1,0 +1,6 @@
+package com.mealsmadeeasy.model
+
+data class Filter(
+        val name: String,
+        val id: String
+)

--- a/app/src/main/java/com/mealsmadeeasy/model/FilterGroup.kt
+++ b/app/src/main/java/com/mealsmadeeasy/model/FilterGroup.kt
@@ -1,0 +1,8 @@
+package com.mealsmadeeasy.model
+
+data class FilterGroup(
+        val groupId: String,
+        val groupName: String,
+        val filters: List<Filter>,
+        val maximumActive: Int = filters.size
+)

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.10'
+    ext.kotlin_version = '1.2.30'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:3.1.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 08 16:29:36 EST 2017
+#Wed Mar 28 00:20:54 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Depends on #46.

This adds the framework necessary to perform searching with network calls. When you go to use this, consider using [`Observable.debounce(long, TimeUnit)`](http://reactivex.io/documentation/operators/debounce.html) to reduce the number of API calls you make.